### PR TITLE
Add check network skill, start and stop skill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 /.clangd/
 CMakeLists.txt.user*
 /ros2_example/
+.vscode
+.devcontainer

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,8 @@ CMakeLists.txt.user*
 /ros2_example/
 .vscode
 .devcontainer
+ros2prova/**/build
+ros2prova/**/install
+ros2prova/**/log
+ros2prova/lifecycle_py/*
+ros2prova/stop_start_component

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Convince_simple_bts
 
 ## TODO
-- Test connection lost between two machines.
-- Make it sudoless.
+- Test with unreachable site. Something that triggers the condition.
 - Modularly define the program to start and stop at runtime. [Right now it is a single program. Make it more than one]
+    what did i even mean here?
 - Turn Misael's code into a lifecycle node.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # Convince_simple_bts
+
+## TODO
+- Test connection lost between two machines.
+- Make it sudoless.
+- Modularly define the program to start and stop at runtime. [Right now it is a single program. Make it more than one]
+- Turn Misael's code into a lifecycle node.

--- a/ros2prova/BT/simple_bt.xml
+++ b/ros2prova/BT/simple_bt.xml
@@ -3,11 +3,14 @@
     <!-- ////////// -->
     <BehaviorTree ID="BehaviorTree">
         <ReactiveSequence>
-            <ReactiveFallback>
+            <!-- <ReactiveFallback>
                 <Condition ID="ROS2Condition" interface="service" name="BatteryLevel" nodeName="BatteryLevelSkill" topicName="/BatteryLevelSkill"/>
                 <Action ID="ROS2Action" interface="service" name="Alarm" nodeName="AlarmBatteryLowSkill" topicName="/AlarmBatteryLowSkill"/>
-            </ReactiveFallback>
-            <Action ID="ROS2Action" interface="service" name="BatteryDrainer" nodeName="BatteryDrainerSkill" topicName="/BatteryDrainerSkill"/>
+            </ReactiveFallback> -->
+            <!-- <Action ID="ROS2Action" interface="service" name="BatteryDrainer" nodeName="BatteryDrainerSkill" topicName="/BatteryDrainerSkill"/> -->
+            <Action ID="ROS2Action" interface="service" name="CheckNetwork" nodeName="CheckNetworkSkill" topicName="/CheckNetworkSkill" />
+            <!-- <Action ID="ROS2Action" interface="service" name="StartServices" nodeName="StartServicesSkill" topicName="/StartServicesSkill" />
+            <Action ID="ROS2Action" interface="service" name="StopServices" nodeName="StopServicesSkill" topicName="/StopServicesSkill" /> -->
         </ReactiveSequence>
     </BehaviorTree>
     <!-- ////////// -->

--- a/ros2prova/check_network_skill/CMakeLists.txt
+++ b/ros2prova/check_network_skill/CMakeLists.txt
@@ -1,0 +1,54 @@
+cmake_minimum_required(VERSION 3.16)
+project(check_network_skill)
+# set(CMAKE_CXX_STANDARD 20)
+# set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(bt_interfaces REQUIRED)
+find_package(sensor_msgs REQUIRED)
+find_package(Qt6 COMPONENTS Core Scxml StateMachine  REQUIRED)
+add_executable(${PROJECT_NAME} )
+
+if (NOT Qt6_FOUND)
+  message("qt6 not found")
+endif()
+
+# find dependencies
+# uncomment the following section in order to fill in
+# further dependencies manually.
+# find_package(<dependency> REQUIRED)
+
+ament_target_dependencies(${PROJECT_NAME} bt_interfaces sensor_msgs rclcpp)
+target_link_libraries(${PROJECT_NAME} Qt6::Core Qt6::Scxml Qt6::StateMachine)
+target_include_directories(${PROJECT_NAME}
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>)
+target_sources( ${PROJECT_NAME} PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp 
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/CheckNetworkSkill.cpp 
+  ${CMAKE_CURRENT_SOURCE_DIR}/include/CheckNetworkSkill.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/CheckNetworkDataModel.cpp 
+  ${CMAKE_CURRENT_SOURCE_DIR}/include/CheckNetworkDataModel.h)
+
+
+install(TARGETS ${PROJECT_NAME}
+DESTINATION lib/${PROJECT_NAME})
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  # the following line skips the linter which checks for copyrights
+  # comment the line when a copyright and license is added to all source files
+  set(ament_cmake_copyright_FOUND TRUE)
+  # the following line skips cpplint (only works in a git repo)
+  # comment the line when this package is in a git repo and when
+  # a copyright and license is added to all source files
+  set(ament_cmake_cpplint_FOUND TRUE)
+  ament_lint_auto_find_test_dependencies()
+endif()
+qt6_add_statecharts(${PROJECT_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/src/CheckNetworkSkillSM.scxml)
+
+ament_package()

--- a/ros2prova/check_network_skill/include/CheckNetworkDataModel.h
+++ b/ros2prova/check_network_skill/include/CheckNetworkDataModel.h
@@ -1,0 +1,81 @@
+/******************************************************************************
+ *                                                                            *
+ * Copyright (C) 2020 Fondazione Istituto Italiano di Tecnologia (IIT)        *
+ * All Rights Reserved.                                                       *
+ *                                                                            *
+ ******************************************************************************/
+
+#ifndef __CHECKNETWORKDATAMODEL_H_
+#define __CHECKNETWORKDATAMODEL_H_
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <QScxmlCppDataModel>
+#include <QVariantMap>
+#include <QTime>
+#include <QTimer>
+#include <QDebug>
+
+// Ping utility structs
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netdb.h>
+#include <unistd.h>
+#include <arpa/inet.h>
+#include <netinet/ip_icmp.h>
+
+// Packet struct
+constexpr int PING_PKT_S = 64;
+
+struct ping_pkt {
+    struct icmphdr hdr;
+    char msg[PING_PKT_S - sizeof(struct icmphdr)];
+};
+
+class CheckNetworkDataModel: public QScxmlCppDataModel
+{
+    Q_SCXML_DATAMODEL
+
+public:
+    CheckNetworkDataModel() = default;
+    void set_name(std::string name);
+    bool close();
+    void spin();
+    void topic_callback();
+    bool start() ;
+    bool setup(const QVariantMap& initialDataValues) override;
+private: 
+    std::string m_name = "CheckNetworkDataModel";
+    int m_msg_count = 0;
+    bool m_is_connected = true;
+    std::shared_ptr<std::thread> m_thread;
+    rclcpp::TimerBase::SharedPtr timer_;
+    
+    std::string m_address_name;
+    std::shared_ptr<rclcpp::Node> m_node;
+    
+    //host can be either the name of the resource (e.g. r1-base) or its ip addr.
+    bool isNetworkConnected(const std::string& host);
+
+    // Calculating the Check Sum
+    // TODO: understand what is this
+    unsigned short checksum(void* b, int len)
+    {
+        unsigned short* buf = static_cast<unsigned short*>(b);
+        unsigned int sum = 0;
+        unsigned short result;
+    
+        for (sum = 0; len > 1; len -= 2)
+            sum += *buf++;
+        if (len == 1)
+            sum += *(unsigned char*)buf;
+        sum = (sum > 16) + (sum & 0xFFFF);
+        sum += (sum > 16);
+        result = ~sum;
+        return result;
+    }
+};
+
+Q_DECLARE_METATYPE(::CheckNetworkDataModel*)
+
+#endif

--- a/ros2prova/check_network_skill/include/CheckNetworkDataModel.h
+++ b/ros2prova/check_network_skill/include/CheckNetworkDataModel.h
@@ -56,6 +56,7 @@ private:
     
     //host can be either the name of the resource (e.g. r1-base) or its ip addr.
     bool isNetworkConnected(const std::string& host);
+    std::string exec(const char* cmd);
 
     // Calculating the Check Sum
     // TODO: understand what is this

--- a/ros2prova/check_network_skill/include/CheckNetworkSkill.h
+++ b/ros2prova/check_network_skill/include/CheckNetworkSkill.h
@@ -1,0 +1,42 @@
+/******************************************************************************
+ *                                                                            *
+ * Copyright (C) 2020 Fondazione Istituto Italiano di Tecnologia (IIT)        *
+ * All Rights Reserved.                                                       *
+ *                                                                            *
+ ******************************************************************************/
+
+# pragma once
+
+#include <thread>
+#include <rclcpp/rclcpp.hpp>
+#include "CheckNetworkSkillSM.h"
+#include "CheckNetworkDataModel.h"
+#include <bt_interfaces/msg/request_ack.hpp>
+#include <bt_interfaces/srv/request_ack.hpp>
+#include <bt_interfaces/srv/send_start.hpp>
+#include <bt_interfaces/srv/send_stop.hpp>
+
+class CheckNetworkSkill
+{
+public:
+    CheckNetworkSkill(std::string name );
+
+    bool start(int argc, char * argv[]);
+    static void spin(std::shared_ptr<rclcpp::Node> node);
+    void request_ack( [[maybe_unused]] const std::shared_ptr<bt_interfaces::srv::RequestAck::Request> request,
+          std::shared_ptr<bt_interfaces::srv::RequestAck::Response>      response);
+    void send_start( [[maybe_unused]] const std::shared_ptr<bt_interfaces::srv::SendStart::Request> request,
+                     [[maybe_unused]] std::shared_ptr<bt_interfaces::srv::SendStart::Response>      response);
+    void send_stop([[maybe_unused]] const std::shared_ptr<bt_interfaces::srv::SendStop::Request> request,
+                   [[maybe_unused]] std::shared_ptr<bt_interfaces::srv::SendStop::Response>      response);
+
+private:
+    std::shared_ptr<std::thread> m_threadSpin;
+    std::shared_ptr<rclcpp::Node> m_node;
+    rclcpp::Service<bt_interfaces::srv::RequestAck>::SharedPtr m_requestAckService;
+    rclcpp::Service<bt_interfaces::srv::SendStart>::SharedPtr m_sendStartService;
+    rclcpp::Service<bt_interfaces::srv::SendStop>::SharedPtr m_sendStopService;
+    std::string m_name;
+    CheckNetworkDataModel m_dataModel;
+    CheckNetworkSkillSM m_stateMachine;
+};

--- a/ros2prova/check_network_skill/package.xml
+++ b/ros2prova/check_network_skill/package.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>check_network_skill</name>
+  <version>0.0.0</version>
+  <description>TODO: Package description</description>
+  <maintainer email="stefano.bernagozzi@iit.it">Stefano Bernagozzi</maintainer>
+  <license>TODO: License declaration</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <depend>bt_interfaces</depend>
+  <depend>sensor_msgs</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+  <member_of_group>rosidl_interface_packages</member_of_group>
+  <exec_depend>rosidl_default_runtime</exec_depend>
+
+  <build_depend>rosidl_default_generators</build_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/ros2prova/check_network_skill/src/CheckNetworkDataModel.cpp
+++ b/ros2prova/check_network_skill/src/CheckNetworkDataModel.cpp
@@ -14,6 +14,7 @@
 
 // Includes to perform ping
 #include <iostream>
+#include <regex>
 #include <chrono>
 
 using namespace std::chrono_literals;
@@ -34,7 +35,7 @@ bool CheckNetworkDataModel::setup(const QVariantMap &initialDataValues)
     }
     
     m_node = rclcpp::Node::make_shared(m_name);
-    m_address_name = "127.0.0.1";
+    m_address_name = "example.com";
 
     timer_ = m_node->create_wall_timer(1000ms, std::bind(&CheckNetworkDataModel::topic_callback, this));
 
@@ -69,68 +70,151 @@ void CheckNetworkDataModel::topic_callback() {
     std::cout << "Our machine is connected? " << m_is_connected;
 }
 
+
+
 bool CheckNetworkDataModel::isNetworkConnected(const std::string& host) {
 
-    struct addrinfo hints, *res;
-    struct sockaddr_in r_addr;
-    socklen_t r_addr_len;
-    int sockfd;
+    double threshold = 3000.;
     bool is_connected = false;
+    const std::string ping_command = "ping -c 4 -w 4 -q " + host + " 2>&1";  // Ping 4 times
+    std::string ping_output = exec(ping_command.c_str());
 
-    // Setup hints
-    memset(&hints, 0, sizeof(hints));
-    hints.ai_family = AF_INET;
-    hints.ai_socktype = SOCK_RAW;
-    hints.ai_protocol = IPPROTO_ICMP;
+    std::cout << "ping_output\n" << ping_output << std::endl;
 
-    // Get address info -> this will take care of the dns lookup if needed
-    if (getaddrinfo(host.c_str(), NULL, &hints, &res) != 0) {
-        return false;
-    }
-
-    // Create socket
-    // sockfd = socket(res->ai_family, res->ai_socktype, res->ai_protocol);
-    sockfd = socket(AF_INET, SOCK_RAW, IPPROTO_ICMP);
-    if (sockfd == -1) {
-        std::cout << "Failed to create socket" << std::endl;
-        freeaddrinfo(res);
-        return false;
-    }
-
-    // Build a packet to send to host
-    struct ping_pkt pckt;
-    memset(&pckt,0,sizeof(pckt));
-    pckt.hdr.type = ICMP_ECHO;
-    pckt.hdr.un.echo.id = getpid();
-    for (std::size_t i = 0; i<sizeof(pckt.msg) - 1; i++)
-        pckt.msg[i] = i + '0';
-
-    pckt.msg[sizeof(pckt.msg)-1] = 0;
-    pckt.hdr.un.echo.sequence = m_msg_count++;
-    pckt.hdr.checksum = checksum(& pckt, sizeof(pckt));
-
-    // Send a packet to the host
-    int bytes_sent = sendto(sockfd,&pckt,sizeof(pckt),0,res->ai_addr,res->ai_addrlen);
-    if(bytes_sent == -1) {
-        std::cout << "Failed to send packet address" << std::endl;
-        freeaddrinfo(res);
-        return false;
-    }
-
-    // Receive a packet
-    char rbuffer[128];
-    int bytes_received = recvfrom(sockfd,rbuffer,sizeof(rbuffer),0,
-                                    (struct sockaddr*) &r_addr, &r_addr_len);
-    if(bytes_received == -1) {
-        std::cout << "Failed to receive packets" << std::endl;
+    if(ping_output.find("Temporary failure in name resolution") != std::string::npos){
+        std::cout << "I am not connected to internet!" << std::endl;
         is_connected = false;
+        return is_connected;
+    }
+
+    auto ping_output_stream = std::stringstream{ping_output};
+    std::string line;
+
+    std::string packets_summary_line;
+    std::string rtt_summary_line;
+
+    std::vector<std::string> ping_output_lines;
+    while(std::getline(ping_output_stream,line,'\n'))
+    {
+        ping_output_lines.push_back(line);
+    }
+
+    if(ping_output_lines.size() >= 3){
+        packets_summary_line = ping_output_lines[3];
+
+    }
+    if(ping_output_lines.size() >= 4){
+        rtt_summary_line = ping_output_lines[4];
+    }
+
+    std::cout << packets_summary_line << std::endl;
+    std::cout << rtt_summary_line << std::endl;
+
+    std::regex rgx_packets(" (\\d*)\\% packet loss");
+    std::regex rgx_ttl("= \\d*\\.\\d*\\/(\\d*[.]\\d*)\\/");
+    std::smatch match_packets;
+    std::smatch match_ttl;
+
+    if(std::regex_search(packets_summary_line, match_packets, rgx_packets))
+        std::cout << "match:" << match_packets[1] << std::endl;
+
+    if(std::regex_search(rtt_summary_line,match_ttl,rgx_ttl))
+        std::cout << "match: " << match_ttl[1] << std::endl;
+
+    double packet_loss = stod(match_packets[1]);
+    double rtt = stod(match_ttl[1]);
+
+    if(packet_loss < 100.){
+        if(rtt < threshold)
+            is_connected = true;
+        else 
+            is_connected = false;
     }
 
     if(is_connected){
         std::cout << "is connected!" << std::endl;
     }
 
-    freeaddrinfo(res);
-
     return is_connected;
+
 }
+
+std::string CheckNetworkDataModel::exec(const char* cmd) {
+    
+    std::array<char, 128> buffer;
+    std::string result; //The ping output string
+    std::unique_ptr<FILE, decltype(&pclose)> pipe(popen(cmd, "r"), pclose);
+    if (!pipe) {
+        throw std::runtime_error("popen() failed!");
+    }
+    while (fgets(buffer.data(), buffer.size(), pipe.get()) != nullptr) {
+        result += buffer.data();
+    }
+    return result;
+}
+
+// bool CheckNetworkDataModel::isNetworkConnected(const std::string& host) {
+
+//     struct addrinfo hints, *res;
+//     struct sockaddr_in r_addr;
+//     socklen_t r_addr_len;
+//     int sockfd;
+//     bool is_connected = false;
+
+//     // Setup hints
+//     memset(&hints, 0, sizeof(hints));
+//     hints.ai_family = AF_INET;
+//     hints.ai_socktype = SOCK_RAW;
+//     hints.ai_protocol = IPPROTO_ICMP;
+
+//     // Get address info -> this will take care of the dns lookup if needed
+//     if (getaddrinfo(host.c_str(), NULL, &hints, &res) != 0) {
+//         return false;
+//     }
+
+//     // Create socket
+//     // sockfd = socket(res->ai_family, res->ai_socktype, res->ai_protocol);
+//     sockfd = socket(AF_INET, SOCK_RAW, IPPROTO_ICMP);
+//     if (sockfd == -1) {
+//         std::cout << "Failed to create socket" << std::endl;
+//         freeaddrinfo(res);
+//         return false;
+//     }
+
+//     // Build a packet to send to host
+//     struct ping_pkt pckt;
+//     memset(&pckt,0,sizeof(pckt));
+//     pckt.hdr.type = ICMP_ECHO;
+//     pckt.hdr.un.echo.id = getpid();
+//     for (std::size_t i = 0; i<sizeof(pckt.msg) - 1; i++)
+//         pckt.msg[i] = i + '0';
+
+//     pckt.msg[sizeof(pckt.msg)-1] = 0;
+//     pckt.hdr.un.echo.sequence = m_msg_count++;
+//     pckt.hdr.checksum = checksum(& pckt, sizeof(pckt));
+
+//     // Send a packet to the host
+//     int bytes_sent = sendto(sockfd,&pckt,sizeof(pckt),0,res->ai_addr,res->ai_addrlen);
+//     if(bytes_sent == -1) {
+//         std::cout << "Failed to send packet address" << std::endl;
+//         freeaddrinfo(res);
+//         return false;
+//     }
+
+//     // Receive a packet
+//     char rbuffer[128];
+//     int bytes_received = recvfrom(sockfd,rbuffer,sizeof(rbuffer),0,
+//                                     (struct sockaddr*) &r_addr, &r_addr_len);
+//     if(bytes_received == -1) {
+//         std::cout << "Failed to receive packets" << std::endl;
+//         is_connected = false;
+//     }
+
+//     if(is_connected){
+//         std::cout << "is connected!" << std::endl;
+//     }
+
+//     freeaddrinfo(res);
+
+//     return is_connected;
+// }

--- a/ros2prova/check_network_skill/src/CheckNetworkDataModel.cpp
+++ b/ros2prova/check_network_skill/src/CheckNetworkDataModel.cpp
@@ -1,0 +1,136 @@
+/******************************************************************************
+ *                                                                            *
+ * Copyright (C) 2024 Fondazione Istituto Italiano di Tecnologia (IIT)        *
+ * All Rights Reserved.                                                       *
+ *                                                                            *
+ ******************************************************************************/
+
+#include "CheckNetworkDataModel.h"
+
+#include <QDebug>
+#include <QTimer>
+#include <QScxmlStateMachine>
+#include <thread>
+
+// Includes to perform ping
+#include <iostream>
+#include <chrono>
+
+using namespace std::chrono_literals;
+
+
+void CheckNetworkDataModel::set_name(std::string name)
+{
+    m_name=name; 
+}
+
+bool CheckNetworkDataModel::setup(const QVariantMap &initialDataValues)
+{
+    Q_UNUSED(initialDataValues)
+
+    if(!rclcpp::ok())
+    {
+        rclcpp::init(/*argc*/ 0, /*argv*/ nullptr);
+    }
+    
+    m_node = rclcpp::Node::make_shared(m_name);
+    m_address_name = "127.0.0.1";
+
+    timer_ = m_node->create_wall_timer(1000ms, std::bind(&CheckNetworkDataModel::topic_callback, this));
+
+    RCLCPP_DEBUG(m_node->get_logger(), "CheckNetworkDataModel::start");
+    m_thread = std::make_shared<std::thread>([this]{ start();});
+    return true;
+}
+
+
+bool CheckNetworkDataModel::close()
+{
+    rclcpp::shutdown();
+    return true;
+}
+
+void CheckNetworkDataModel::spin()
+{
+    rclcpp::spin(m_node);
+}
+
+bool CheckNetworkDataModel::start() {
+    std::cout << "Before spinning" << std::endl;
+    spin();  
+    std::cout << "Finished spinning" << std::endl;
+    close();
+    return true;
+}
+
+void CheckNetworkDataModel::topic_callback() {
+    std::cout << "CALLBACK" << std::endl;
+    m_is_connected = isNetworkConnected(m_address_name);
+    std::cout << "Our machine is connected? " << m_is_connected;
+}
+
+bool CheckNetworkDataModel::isNetworkConnected(const std::string& host) {
+
+    struct addrinfo hints, *res;
+    struct sockaddr_in r_addr;
+    socklen_t r_addr_len;
+    int sockfd;
+    bool is_connected = false;
+
+    // Setup hints
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = AF_INET;
+    hints.ai_socktype = SOCK_RAW;
+    hints.ai_protocol = IPPROTO_ICMP;
+
+    // Get address info -> this will take care of the dns lookup if needed
+    if (getaddrinfo(host.c_str(), NULL, &hints, &res) != 0) {
+        return false;
+    }
+
+    // Create socket
+    // sockfd = socket(res->ai_family, res->ai_socktype, res->ai_protocol);
+    sockfd = socket(AF_INET, SOCK_RAW, IPPROTO_ICMP);
+    if (sockfd == -1) {
+        std::cout << "Failed to create socket" << std::endl;
+        freeaddrinfo(res);
+        return false;
+    }
+
+    // Build a packet to send to host
+    struct ping_pkt pckt;
+    memset(&pckt,0,sizeof(pckt));
+    pckt.hdr.type = ICMP_ECHO;
+    pckt.hdr.un.echo.id = getpid();
+    for (std::size_t i = 0; i<sizeof(pckt.msg) - 1; i++)
+        pckt.msg[i] = i + '0';
+
+    pckt.msg[sizeof(pckt.msg)-1] = 0;
+    pckt.hdr.un.echo.sequence = m_msg_count++;
+    pckt.hdr.checksum = checksum(& pckt, sizeof(pckt));
+
+    // Send a packet to the host
+    int bytes_sent = sendto(sockfd,&pckt,sizeof(pckt),0,res->ai_addr,res->ai_addrlen);
+    if(bytes_sent == -1) {
+        std::cout << "Failed to send packet address" << std::endl;
+        freeaddrinfo(res);
+        return false;
+    }
+
+    // Receive a packet
+    char rbuffer[128];
+    int bytes_received = recvfrom(sockfd,rbuffer,sizeof(rbuffer),0,
+                                    (struct sockaddr*) &r_addr, &r_addr_len);
+    if(bytes_received == -1) {
+        std::cout << "Failed to receive packets" << std::endl;
+        is_connected = false;
+    }
+
+    if(is_connected){
+        std::cout << "is connected!" << std::endl;
+    }
+
+    freeaddrinfo(res);
+
+    return is_connected;
+}

--- a/ros2prova/check_network_skill/src/CheckNetworkSkill.cpp
+++ b/ros2prova/check_network_skill/src/CheckNetworkSkill.cpp
@@ -1,0 +1,116 @@
+/******************************************************************************
+ *                                                                            *
+ * Copyright (C) 2020 Fondazione Istituto Italiano di Tecnologia (IIT)        *
+ * All Rights Reserved.                                                       *
+ *                                                                            *
+ ******************************************************************************/
+
+#include "CheckNetworkSkill.h"
+
+#include <QTimer>
+#include <QDebug>
+#include <QTime>
+#include <iostream>
+#include <QStateMachine>
+
+CheckNetworkSkill::CheckNetworkSkill(std::string name ) :
+        m_name(std::move(name))
+{
+    m_dataModel.set_name(name+"dataModel");
+    m_stateMachine.setDataModel(&m_dataModel);
+}
+
+
+void CheckNetworkSkill::spin(std::shared_ptr<rclcpp::Node> node)
+{
+    rclcpp::spin(node);  
+    rclcpp::shutdown();  
+}
+
+
+bool CheckNetworkSkill::start(int argc, char*argv[])
+{
+
+    if(!rclcpp::ok())
+    {
+        rclcpp::init(/*argc*/ argc, /*argv*/ argv);
+    }
+
+    m_node = rclcpp::Node::make_shared(m_name);
+
+    
+    RCLCPP_DEBUG(m_node->get_logger(), "CheckNetworkSkill::start");
+    std::cout << "CheckNetworkSkill::start";
+    m_requestAckService = m_node->create_service<bt_interfaces::srv::RequestAck>("/CheckNetworkSkill/RequestAck",  
+                                                                                std::bind(&CheckNetworkSkill::request_ack,
+                                                                                this,
+                                                                                std::placeholders::_1,
+                                                                                std::placeholders::_2));
+    m_sendStartService = m_node->create_service<bt_interfaces::srv::SendStart>("/CheckNetworkSkill/SendStart",  
+                                                                                std::bind(&CheckNetworkSkill::send_start,
+                                                                                this,
+                                                                                std::placeholders::_1,
+                                                                                std::placeholders::_2));
+    m_sendStopService = m_node->create_service<bt_interfaces::srv::SendStop>("/CheckNetworkSkill/SendStop",  
+                                                                                std::bind(&CheckNetworkSkill::send_stop,
+                                                                                this,
+                                                                                std::placeholders::_1,
+                                                                                std::placeholders::_2));
+
+    m_stateMachine.start();
+    m_threadSpin = std::make_shared<std::thread>(spin, m_node);
+    return true;
+}
+
+void CheckNetworkSkill::request_ack( [[maybe_unused]] const std::shared_ptr<bt_interfaces::srv::RequestAck::Request> request,
+                                       std::shared_ptr<bt_interfaces::srv::RequestAck::Response>      response)
+{
+    RCLCPP_DEBUG(m_node->get_logger(), "CheckNetworkSkill::request_ack");    
+    std::cout <<  "CheckNetworkSkill::request_ack\n";    
+
+    auto message = bt_interfaces::msg::RequestAck();
+    for (const auto& state : m_stateMachine.activeStateNames()) {
+        if (state == "idle") {
+            std::cout << "STATE:IDLE" << std::endl;
+            m_stateMachine.submitEvent("CMD_START");
+            response->status.status = message.SKILL_IDLE;
+            response->is_ok = true;
+        }
+        if (state == "get") {
+            std::cout << "STATE:GET" << std::endl;
+            m_stateMachine.submitEvent("CMD_OK");
+            response->status.status = message.SKILL_IDLE;
+            response->is_ok = true;
+        }
+        if (state == "success") {
+            std::cout << "STATE:SUC" << std::endl;
+            m_stateMachine.submitEvent("CMD_OK");
+            response->status.status = message.SKILL_SUCCESS;
+            response->is_ok = true;
+        }
+        if (state == "failure") {
+            std::cout << "STATE:FAIL" << std::endl;
+            m_stateMachine.submitEvent("CMD_OK");
+            response->status.status = message.SKILL_FAILURE;
+            response->is_ok = true;
+        }
+    }
+}
+void CheckNetworkSkill::send_start( [[maybe_unused]] const std::shared_ptr<bt_interfaces::srv::SendStart::Request> request,
+                                       [[maybe_unused]] std::shared_ptr<bt_interfaces::srv::SendStart::Response>      response)
+{
+    RCLCPP_DEBUG(m_node->get_logger(), "CheckNetworkSkill::send_start");    
+    std::cout << "CheckNetworkSkill::send_start";    
+    m_stateMachine.submitEvent("CMD_START");
+    response->is_ok = true;
+}
+
+void CheckNetworkSkill::send_stop( [[maybe_unused]] const std::shared_ptr<bt_interfaces::srv::SendStop::Request> request,
+                                       [[maybe_unused]] std::shared_ptr<bt_interfaces::srv::SendStop::Response>      response)
+{
+
+    RCLCPP_DEBUG(m_node->get_logger(), "CheckNetworkSkill::send_stop");    
+    std::cout <<  "CheckNetworkSkill::send_stop";    
+    m_stateMachine.submitEvent("CMD_STOP",  QStateMachine::HighPriority);
+    response->is_ok = true;
+}

--- a/ros2prova/check_network_skill/src/CheckNetworkSkillSM.scxml
+++ b/ros2prova/check_network_skill/src/CheckNetworkSkillSM.scxml
@@ -1,0 +1,33 @@
+<scxml 
+  initial="idle" 
+  version="1.0" 
+  name="CheckNetworkSkillSM"
+  datamodel="cplusplus:CheckNetworkDataModel:CheckNetworkDataModel.h"
+  xmlns="http://www.w3.org/2005/07/scxml">
+
+    <state id="idle">
+        <transition event="CMD_START" target="get" />
+    </state>
+
+    <state id="get">
+        <onentry>
+            <script>
+                QTimer::singleShot(0, stateMachine(), [=](){
+                    stateMachine()->submitEvent((m_is_connected) ? "STATUS_SUCCESS" : "STATUS_FAILED");
+                });
+            </script>
+        </onentry>
+        <transition event="STATUS_SUCCESS" target="success" />
+        <transition event="STATUS_FAILED" target="failure" />
+    </state>
+
+    <state id="success">
+        <transition event="CMD_OK" target="idle" />
+    </state>
+
+    <state id="failure">
+        <transition event="CMD_OK" target="idle" />
+
+    </state>
+</scxml>
+

--- a/ros2prova/check_network_skill/src/main.cpp
+++ b/ros2prova/check_network_skill/src/main.cpp
@@ -1,0 +1,22 @@
+#include <QCoreApplication>
+#include <QScxmlStateMachine>
+#include <QDebug>
+
+#include <iostream>
+#include "CheckNetworkSkill.h"
+
+#include <thread>
+#include <chrono>
+
+int main(int argc, char *argv[])
+{
+  QCoreApplication app(argc, argv);
+  CheckNetworkSkill stateMachine("CheckNetwork");
+  stateMachine.start(argc, argv);
+
+  int ret=app.exec();
+
+  return ret;
+
+}
+

--- a/ros2prova/cyclone_dds_settings.xml
+++ b/ros2prova/cyclone_dds_settings.xml
@@ -3,7 +3,7 @@
       <General>
          <AllowMulticast>false</AllowMulticast>
          <Interfaces>
-            <NetworkInterface address="172.17.0.1" priority="default"/>
+            <NetworkInterface address="127.0.0.1" priority="default"/>
          </Interfaces>
       </General>
       <Discovery>
@@ -11,7 +11,7 @@
          <ParticipantIndex>auto</ParticipantIndex>
          <Peers>
             <Peer address="localhost"/>
-            <Peer address="172.17.0.1"/>
+            <Peer address="127.0.0.1"/>
          </Peers>
       </Discovery>
    </Domain>

--- a/ros2prova/launch/bt_launch_network.py
+++ b/ros2prova/launch/bt_launch_network.py
@@ -5,17 +5,17 @@ from launch_ros.actions import Node
 def generate_launch_description():
     return LaunchDescription([
         Node(
-            package='stop_services_skill',
-            executable='stop_services_skill',
+            package='check_network_skill',
+            executable='check_network_skill',
             output='screen',
             arguments=['--ros-args','--log-level', 'debug']
         ),
-        Node(
-            package='start_services_skill',
-            executable='start_services_skill',
-            output='screen',
-            arguments=['--ros-args','--log-level', 'debug']
-        ),
+        # Node(
+        #     package='start_services_skill',
+        #     executable='start_services_skill',
+        #     output='screen',
+        #     arguments=['--ros-args','--log-level', 'debug']
+        # ),
         # Node(
         #     package='alarm_battery_low_skill',
         #     executable='alarm_battery_low_skill',

--- a/ros2prova/start_services_skill/CMakeLists.txt
+++ b/ros2prova/start_services_skill/CMakeLists.txt
@@ -1,0 +1,54 @@
+cmake_minimum_required(VERSION 3.8)
+project(start_services_skill)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(rclcpp_lifecycle REQUIRED)
+find_package(lifecycle_msgs REQUIRED)
+find_package(bt_interfaces REQUIRED)
+find_package(other_interfaces REQUIRED)
+find_package(Qt6 COMPONENTS Core Scxml StateMachine  REQUIRED)
+add_executable(${PROJECT_NAME} )
+
+if (NOT Qt6_FOUND)
+  message("qt6 not found")
+endif()
+
+# find dependencies
+# uncomment the following section in order to fill in
+# further dependencies manually.
+# find_package(<dependency> REQUIRED)
+
+ament_target_dependencies(${PROJECT_NAME} bt_interfaces other_interfaces rclcpp rclcpp_lifecycle lifecycle_msgs)
+target_link_libraries(${PROJECT_NAME} Qt6::Core Qt6::Scxml Qt6::StateMachine)
+target_include_directories(${PROJECT_NAME}
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>)
+target_sources( ${PROJECT_NAME} PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp 
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/StartServicesSkill.cpp 
+  ${CMAKE_CURRENT_SOURCE_DIR}/include/StartServicesSkill.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/StartServicesDataModel.cpp 
+  ${CMAKE_CURRENT_SOURCE_DIR}/include/StartServicesDataModel.h)
+
+
+install(TARGETS ${PROJECT_NAME}
+DESTINATION lib/${PROJECT_NAME})
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  # the following line skips the linter which checks for copyrights
+  # comment the line when a copyright and license is added to all source files
+  set(ament_cmake_copyright_FOUND TRUE)
+  # the following line skips cpplint (only works in a git repo)
+  # comment the line when this package is in a git repo and when
+  # a copyright and license is added to all source files
+  set(ament_cmake_cpplint_FOUND TRUE)
+  ament_lint_auto_find_test_dependencies()
+endif()
+qt6_add_statecharts(${PROJECT_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/src/StartServicesSkillSM.scxml)
+
+ament_package()

--- a/ros2prova/start_services_skill/include/StartServicesDataModel.h
+++ b/ros2prova/start_services_skill/include/StartServicesDataModel.h
@@ -1,0 +1,43 @@
+/******************************************************************************
+ *                                                                            *
+ * Copyright (C) 2020 Fondazione Istituto Italiano di Tecnologia (IIT)        *
+ * All Rights Reserved.                                                       *
+ *                                                                            *
+ ******************************************************************************/
+
+#pragma once
+
+#include <QScxmlCppDataModel>
+#include <QVariantMap>
+#include <rclcpp/rclcpp.hpp>
+#include <QTime>
+#include <QTimer>
+#include <QDebug>
+
+#include "lifecycle_msgs/srv/get_state.hpp"
+#include "lifecycle_msgs/srv/change_state.hpp" 
+#include <optional>
+
+using namespace std::chrono_literals;
+
+class StartServicesDataModel: public QScxmlCppDataModel
+{
+    Q_SCXML_DATAMODEL
+
+public:
+    StartServicesDataModel() = default;
+    bool start();
+    void set_name(std::string name);
+    bool setup(const QVariantMap& initialDataValues) override;
+private: 
+    std::shared_ptr<rclcpp::Node> m_node;
+    rclcpp::Client<lifecycle_msgs::srv::GetState>::SharedPtr m_client_get_state;
+    rclcpp::Client<lifecycle_msgs::srv::ChangeState>::SharedPtr m_client_change_state;
+    std::string m_name = "StartServicesDataModel";
+    std::chrono::seconds m_timeout = 3s;
+
+    bool is_client_available(const std::chrono::seconds& timeout = 3s);
+    std::optional<lifecycle_msgs::msg::State> get_state(const std::chrono::seconds& timeout = 3s);
+};
+
+Q_DECLARE_METATYPE(::StartServicesDataModel*)

--- a/ros2prova/start_services_skill/include/StartServicesSkill.h
+++ b/ros2prova/start_services_skill/include/StartServicesSkill.h
@@ -1,0 +1,42 @@
+/******************************************************************************
+ *                                                                            *
+ * Copyright (C) 2020 Fondazione Istituto Italiano di Tecnologia (IIT)        *
+ * All Rights Reserved.                                                       *
+ *                                                                            *
+ ******************************************************************************/
+
+# pragma once
+
+#include <thread>
+#include <rclcpp/rclcpp.hpp>
+#include "StartServicesSkillSM.h"
+#include "StartServicesDataModel.h"
+#include <bt_interfaces/msg/request_ack.hpp>
+#include <bt_interfaces/srv/request_ack.hpp>
+#include <bt_interfaces/srv/send_start.hpp>
+#include <bt_interfaces/srv/send_stop.hpp>
+
+class StartServicesSkill
+{
+public:
+    StartServicesSkill(std::string name );
+
+    bool start(int argc, char * argv[]);
+    static void spin(std::shared_ptr<rclcpp::Node> node);
+    void request_ack( [[maybe_unused]] const std::shared_ptr<bt_interfaces::srv::RequestAck::Request> request,
+          std::shared_ptr<bt_interfaces::srv::RequestAck::Response>      response);
+    void send_start( [[maybe_unused]] const std::shared_ptr<bt_interfaces::srv::SendStart::Request> request,
+                     [[maybe_unused]] std::shared_ptr<bt_interfaces::srv::SendStart::Response>      response);
+    void send_stop([[maybe_unused]] const std::shared_ptr<bt_interfaces::srv::SendStop::Request> request,
+                   [[maybe_unused]] std::shared_ptr<bt_interfaces::srv::SendStop::Response>      response);
+
+private:
+    std::shared_ptr<std::thread> m_threadSpin;
+    std::shared_ptr<rclcpp::Node> m_node;
+    rclcpp::Service<bt_interfaces::srv::RequestAck>::SharedPtr m_requestAckService;
+    rclcpp::Service<bt_interfaces::srv::SendStart>::SharedPtr m_sendStartService;
+    rclcpp::Service<bt_interfaces::srv::SendStop>::SharedPtr m_sendStopService;
+    std::string m_name;
+    StartServicesDataModel m_dataModel;
+    StartServicesSkillSM m_stateMachine;
+};

--- a/ros2prova/start_services_skill/package.xml
+++ b/ros2prova/start_services_skill/package.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>start_services_skill</name>
+  <version>0.0.0</version>
+  <description>A BT skill that stops the provided service</description>
+  <maintainer email="francesco.brand@iit.it">Stefano Bernagozzi</maintainer>
+  <license>Apache-2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <depend>bt_interfaces</depend>
+  <depend>other_interfaces</depend>
+  <depend>rclcpp</depend>
+  <depend>lifecycle_msgs</depend>
+  <depend>rclcpp_lifecycle</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+  <member_of_group>rosidl_interface_packages</member_of_group>
+  <exec_depend>rosidl_default_runtime</exec_depend>
+
+  <build_depend>rosidl_default_generators</build_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/ros2prova/start_services_skill/src/StartServicesDataModel.cpp
+++ b/ros2prova/start_services_skill/src/StartServicesDataModel.cpp
@@ -1,0 +1,116 @@
+/******************************************************************************
+ *                                                                            *
+ * Copyright (C) 2020 Fondazione Istituto Italiano di Tecnologia (IIT)        *
+ * All Rights Reserved.                                                       *
+ *                                                                            *
+ ******************************************************************************/
+#include "StartServicesDataModel.h"
+
+#include "lifecycle_msgs/msg/state.hpp"
+#include "lifecycle_msgs/msg/transition.hpp"
+
+#include <QDebug>
+#include <QTimer>
+#include <QScxmlStateMachine>
+
+
+
+void StartServicesDataModel::set_name(std::string name)
+{
+    m_name=name; 
+}
+
+bool StartServicesDataModel::setup(const QVariantMap &initialDataValues)
+{
+    Q_UNUSED(initialDataValues)
+
+    if(!rclcpp::ok())
+    {
+        rclcpp::init(/*argc*/ 0, /*argv*/ nullptr);
+    }
+
+    m_node = rclcpp::Node::make_shared(m_name);
+    m_client_get_state = m_node->create_client<lifecycle_msgs::srv::GetState>("/lc_talker/get_state");
+    m_client_change_state = m_node->create_client<lifecycle_msgs::srv::ChangeState>("/lc_talker/change_state");
+
+    RCLCPP_DEBUG(m_node->get_logger(), "StartServicesDataModel::start");
+    std::cout << "StartServicesDataModel::start";
+
+    return true;
+}
+
+bool StartServicesDataModel::is_client_available(const std::chrono::seconds& timeout) {
+
+    // Check if client is available, else return
+    bool is_client_available = m_client_get_state->wait_for_service(timeout);
+    if (!rclcpp::ok()) {
+        RCLCPP_ERROR(rclcpp::get_logger("rclcpp"), "Interrupted while waiting for the service. Exiting.");
+        return false;
+    }
+    if(!is_client_available){
+        RCLCPP_INFO(rclcpp::get_logger("rclcpp"), "service not available, aborting.");
+        return false;
+    }
+
+    return true;
+}
+
+std::optional<lifecycle_msgs::msg::State> StartServicesDataModel::get_state(const std::chrono::seconds& timeout) {
+
+    if(!is_client_available(timeout)) {
+        return std::nullopt;
+    }
+
+    // Get the state of the managed node
+    auto request = std::make_shared<lifecycle_msgs::srv::GetState::Request>();
+    auto result = m_client_get_state->async_send_request(request);
+    
+    if (rclcpp::spin_until_future_complete(m_node, result,timeout) == rclcpp::FutureReturnCode::SUCCESS)
+    {
+        RCLCPP_DEBUG(m_node->get_logger(), "StartServicesDataModel::get_state(). Success");
+        return result.get()->current_state;
+    } else {
+        RCLCPP_DEBUG(m_node->get_logger(), "StartServicesDataModel::get_state(). Failure");
+        return std::nullopt;
+    }
+
+}
+
+bool StartServicesDataModel::start() {
+
+    if(!is_client_available()){
+        return false;
+    }
+
+    // Check if managed node is in state active and make it inactive
+    // Check https://github.com/ros2/rcl_interfaces/blob/humble/lifecycle_msgs/msg/State.msg for reference
+    std::optional<lifecycle_msgs::msg::State> current_state = this->get_state();
+    if(!current_state) {
+        return false;
+    }
+
+    if(current_state.value().id != lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE) {
+        RCLCPP_ERROR(m_node->get_logger(), "Cannot start service since it is not inactive");
+        return false;
+    }
+    else {
+
+        // Change the state of the managed node to inactive
+        // Check https://github.com/ros2/rcl_interfaces/blob/humble/lifecycle_msgs/msg/Transition.msg for reference
+        auto request = std::make_shared<lifecycle_msgs::srv::ChangeState::Request>();
+        request->transition.id = lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE;
+        
+        auto result = m_client_change_state->async_send_request(request);
+        
+        if (rclcpp::spin_until_future_complete(m_node,result,m_timeout) == rclcpp::FutureReturnCode::SUCCESS)
+        {
+            RCLCPP_DEBUG(m_node->get_logger(), "StartServicesDataModel::start(). Success");
+            return true;
+        } else {
+            RCLCPP_DEBUG(m_node->get_logger(), "StartServicesDataModel::start(). Failure");
+            return false;
+        }
+    }
+
+    return true;
+}

--- a/ros2prova/start_services_skill/src/StartServicesDataModel.cpp
+++ b/ros2prova/start_services_skill/src/StartServicesDataModel.cpp
@@ -30,8 +30,8 @@ bool StartServicesDataModel::setup(const QVariantMap &initialDataValues)
     }
 
     m_node = rclcpp::Node::make_shared(m_name);
-    m_client_get_state = m_node->create_client<lifecycle_msgs::srv::GetState>("/lc_talker/get_state");
-    m_client_change_state = m_node->create_client<lifecycle_msgs::srv::ChangeState>("/lc_talker/change_state");
+    m_client_get_state = m_node->create_client<lifecycle_msgs::srv::GetState>("/dr_spaam_ros_node/get_state");
+    m_client_change_state = m_node->create_client<lifecycle_msgs::srv::ChangeState>("/dr_spaam_ros_node/change_state");
 
     RCLCPP_DEBUG(m_node->get_logger(), "StartServicesDataModel::start");
     std::cout << "StartServicesDataModel::start";

--- a/ros2prova/start_services_skill/src/StartServicesSkill.cpp
+++ b/ros2prova/start_services_skill/src/StartServicesSkill.cpp
@@ -1,0 +1,98 @@
+/******************************************************************************
+ *                                                                            *
+ * Copyright (C) 2020 Fondazione Istituto Italiano di Tecnologia (IIT)        *
+ * All Rights Reserved.                                                       *
+ *                                                                            *
+ ******************************************************************************/
+
+#include "StartServicesSkill.h"
+
+#include <QTimer>
+#include <QDebug>
+#include <QTime>
+#include <iostream>
+#include <QStateMachine>
+
+StartServicesSkill::StartServicesSkill(std::string name ) :
+        m_name(std::move(name))
+{
+    m_dataModel.set_name(name+"dataModel");
+    m_stateMachine.setDataModel(&m_dataModel);
+}
+
+
+void StartServicesSkill::spin(std::shared_ptr<rclcpp::Node> node)
+{
+    rclcpp::spin(node);  
+    rclcpp::shutdown();  
+}
+
+
+bool StartServicesSkill::start(int argc, char*argv[])
+{
+
+    if(!rclcpp::ok())
+    {
+        rclcpp::init(/*argc*/ argc, /*argv*/ argv);
+    }
+    m_node = rclcpp::Node::make_shared(m_name);
+
+    
+    RCLCPP_DEBUG(m_node->get_logger(), "StartServicesSkill::start");
+    std::cout << "StartServicesSkill::start";
+    m_requestAckService = m_node->create_service<bt_interfaces::srv::RequestAck>("/StartServicesSkill/RequestAck",  
+                                                                                std::bind(&StartServicesSkill::request_ack,
+                                                                                this,
+                                                                                std::placeholders::_1,
+                                                                                std::placeholders::_2));
+    m_sendStartService = m_node->create_service<bt_interfaces::srv::SendStart>("/StartServicesSkill/SendStart",  
+                                                                                std::bind(&StartServicesSkill::send_start,
+                                                                                this,
+                                                                                std::placeholders::_1,
+                                                                                std::placeholders::_2));
+    m_sendStopService = m_node->create_service<bt_interfaces::srv::SendStop>("/StartServicesSkill/SendStop",  
+                                                                                std::bind(&StartServicesSkill::send_stop,
+                                                                                this,
+                                                                                std::placeholders::_1,
+                                                                                std::placeholders::_2));
+
+    m_stateMachine.start();
+    m_threadSpin = std::make_shared<std::thread>(spin, m_node);
+    return true;
+}
+
+void StartServicesSkill::request_ack( [[maybe_unused]] const std::shared_ptr<bt_interfaces::srv::RequestAck::Request> request,
+                                       std::shared_ptr<bt_interfaces::srv::RequestAck::Response>      response)
+{
+    auto message = bt_interfaces::msg::RequestAck();
+        for (const auto& state : m_stateMachine.activeStateNames()) {
+            if (state == "start") {
+                m_stateMachine.submitEvent("CMD_OK");
+                response->status.status = message.SKILL_RUNNING;
+            }
+            if (state == "idle") {
+                m_stateMachine.submitEvent("CMD_OK");
+                response->status.status = message.SKILL_IDLE;
+            }
+        }
+    response->is_ok = true;
+}
+
+void StartServicesSkill::send_start( [[maybe_unused]] const std::shared_ptr<bt_interfaces::srv::SendStart::Request> request,
+                                       [[maybe_unused]] std::shared_ptr<bt_interfaces::srv::SendStart::Response>      response)
+{
+    RCLCPP_DEBUG(m_node->get_logger(), "StartServicesSkill::send_start");    
+    std::cout << "StartServicesSkill::send_start";    
+    m_stateMachine.submitEvent("CMD_START");
+    response->is_ok = true;
+}
+
+void StartServicesSkill::send_stop( [[maybe_unused]] const std::shared_ptr<bt_interfaces::srv::SendStop::Request> request,
+                                       [[maybe_unused]] std::shared_ptr<bt_interfaces::srv::SendStop::Response>      response)
+{
+
+    RCLCPP_DEBUG(m_node->get_logger(), "StartServicesSkill::send_stop");    
+    std::cout <<  "StartServicesSkill::send_stop";    
+    m_stateMachine.submitEvent("CMD_STOP",  QStateMachine::HighPriority);
+    response->is_ok = true;
+}

--- a/ros2prova/start_services_skill/src/StartServicesSkillSM.scxml
+++ b/ros2prova/start_services_skill/src/StartServicesSkillSM.scxml
@@ -1,0 +1,22 @@
+<scxml 
+  initial="idle" 
+  version="1.0" 
+  name="StartServicesSkillSM"
+  datamodel="cplusplus:StartServicesDataModel:StartServicesDataModel.h"
+  xmlns="http://www.w3.org/2005/07/scxml">
+
+    <state id="start">
+        <onentry>
+            <script>
+                start();
+            </script>
+        </onentry>
+        <transition event="CMD_OK" target="idle"/>
+    </state>
+
+    <state id="idle">
+        <transition event="CMD_START" target="start" />
+    </state>
+    
+</scxml>
+

--- a/ros2prova/start_services_skill/src/main.cpp
+++ b/ros2prova/start_services_skill/src/main.cpp
@@ -1,0 +1,25 @@
+#include <QCoreApplication>
+#include <QScxmlStateMachine>
+#include <QDebug>
+
+
+#include <iostream>
+#include "StartServicesSkill.h"
+
+#include <thread>
+#include <chrono>
+
+
+
+int main(int argc, char *argv[])
+{
+  QCoreApplication app(argc, argv);
+  StartServicesSkill stateMachine("StartServicesSkill");
+  stateMachine.start(argc, argv);
+
+  int ret=app.exec();
+  
+  return ret;
+  
+}
+

--- a/ros2prova/stop_services_skill/CMakeLists.txt
+++ b/ros2prova/stop_services_skill/CMakeLists.txt
@@ -1,0 +1,54 @@
+cmake_minimum_required(VERSION 3.8)
+project(stop_services_skill)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(rclcpp_lifecycle REQUIRED)
+find_package(lifecycle_msgs REQUIRED)
+find_package(bt_interfaces REQUIRED)
+find_package(other_interfaces REQUIRED)
+find_package(Qt6 COMPONENTS Core Scxml StateMachine  REQUIRED)
+add_executable(${PROJECT_NAME} )
+
+if (NOT Qt6_FOUND)
+  message("qt6 not found")
+endif()
+
+# find dependencies
+# uncomment the following section in order to fill in
+# further dependencies manually.
+# find_package(<dependency> REQUIRED)
+
+ament_target_dependencies(${PROJECT_NAME} bt_interfaces other_interfaces rclcpp rclcpp_lifecycle lifecycle_msgs)
+target_link_libraries(${PROJECT_NAME} Qt6::Core Qt6::Scxml Qt6::StateMachine)
+target_include_directories(${PROJECT_NAME}
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>)
+target_sources( ${PROJECT_NAME} PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp 
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/StopServicesSkill.cpp 
+  ${CMAKE_CURRENT_SOURCE_DIR}/include/StopServicesSkill.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/StopServicesDataModel.cpp 
+  ${CMAKE_CURRENT_SOURCE_DIR}/include/StopServicesDataModel.h)
+
+
+install(TARGETS ${PROJECT_NAME}
+DESTINATION lib/${PROJECT_NAME})
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  # the following line skips the linter which checks for copyrights
+  # comment the line when a copyright and license is added to all source files
+  set(ament_cmake_copyright_FOUND TRUE)
+  # the following line skips cpplint (only works in a git repo)
+  # comment the line when this package is in a git repo and when
+  # a copyright and license is added to all source files
+  set(ament_cmake_cpplint_FOUND TRUE)
+  ament_lint_auto_find_test_dependencies()
+endif()
+qt6_add_statecharts(${PROJECT_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/src/StopServicesSkillSM.scxml)
+
+ament_package()

--- a/ros2prova/stop_services_skill/include/StopServicesDataModel.h
+++ b/ros2prova/stop_services_skill/include/StopServicesDataModel.h
@@ -1,0 +1,43 @@
+/******************************************************************************
+ *                                                                            *
+ * Copyright (C) 2020 Fondazione Istituto Italiano di Tecnologia (IIT)        *
+ * All Rights Reserved.                                                       *
+ *                                                                            *
+ ******************************************************************************/
+
+#pragma once
+
+#include <QScxmlCppDataModel>
+#include <QVariantMap>
+#include <rclcpp/rclcpp.hpp>
+#include <QTime>
+#include <QTimer>
+#include <QDebug>
+
+#include "lifecycle_msgs/srv/get_state.hpp"
+#include "lifecycle_msgs/srv/change_state.hpp" 
+#include <optional>
+
+using namespace std::chrono_literals;
+
+class StopServicesDataModel: public QScxmlCppDataModel
+{
+    Q_SCXML_DATAMODEL
+
+public:
+    StopServicesDataModel() = default;
+    bool stop();
+    void set_name(std::string name);
+    bool setup(const QVariantMap& initialDataValues) override;
+private: 
+    std::shared_ptr<rclcpp::Node> m_node;
+    rclcpp::Client<lifecycle_msgs::srv::GetState>::SharedPtr m_client_get_state;
+    rclcpp::Client<lifecycle_msgs::srv::ChangeState>::SharedPtr m_client_change_state;
+    std::string m_name = "StopServicesDataModel";
+    std::chrono::seconds m_timeout = 3s;
+
+    bool is_client_available(const std::chrono::seconds& timeout = 3s);
+    std::optional<lifecycle_msgs::msg::State> get_state(const std::chrono::seconds& timeout = 3s);
+};
+
+Q_DECLARE_METATYPE(::StopServicesDataModel*)

--- a/ros2prova/stop_services_skill/include/StopServicesSkill.h
+++ b/ros2prova/stop_services_skill/include/StopServicesSkill.h
@@ -1,0 +1,42 @@
+/******************************************************************************
+ *                                                                            *
+ * Copyright (C) 2020 Fondazione Istituto Italiano di Tecnologia (IIT)        *
+ * All Rights Reserved.                                                       *
+ *                                                                            *
+ ******************************************************************************/
+
+# pragma once
+
+#include <thread>
+#include <rclcpp/rclcpp.hpp>
+#include "StopServicesSkillSM.h"
+#include "StopServicesDataModel.h"
+#include <bt_interfaces/msg/request_ack.hpp>
+#include <bt_interfaces/srv/request_ack.hpp>
+#include <bt_interfaces/srv/send_start.hpp>
+#include <bt_interfaces/srv/send_stop.hpp>
+
+class StopServicesSkill
+{
+public:
+    StopServicesSkill(std::string name );
+
+    bool start(int argc, char * argv[]);
+    static void spin(std::shared_ptr<rclcpp::Node> node);
+    void request_ack( [[maybe_unused]] const std::shared_ptr<bt_interfaces::srv::RequestAck::Request> request,
+          std::shared_ptr<bt_interfaces::srv::RequestAck::Response>      response);
+    void send_start( [[maybe_unused]] const std::shared_ptr<bt_interfaces::srv::SendStart::Request> request,
+                     [[maybe_unused]] std::shared_ptr<bt_interfaces::srv::SendStart::Response>      response);
+    void send_stop([[maybe_unused]] const std::shared_ptr<bt_interfaces::srv::SendStop::Request> request,
+                   [[maybe_unused]] std::shared_ptr<bt_interfaces::srv::SendStop::Response>      response);
+
+private:
+    std::shared_ptr<std::thread> m_threadSpin;
+    std::shared_ptr<rclcpp::Node> m_node;
+    rclcpp::Service<bt_interfaces::srv::RequestAck>::SharedPtr m_requestAckService;
+    rclcpp::Service<bt_interfaces::srv::SendStart>::SharedPtr m_sendStartService;
+    rclcpp::Service<bt_interfaces::srv::SendStop>::SharedPtr m_sendStopService;
+    std::string m_name;
+    StopServicesDataModel m_dataModel;
+    StopServicesSkillSM m_stateMachine;
+};

--- a/ros2prova/stop_services_skill/package.xml
+++ b/ros2prova/stop_services_skill/package.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>stop_services_skill</name>
+  <version>0.0.0</version>
+  <description>A BT skill that stops the provided service</description>
+  <maintainer email="francesco.brand@iit.it">Stefano Bernagozzi</maintainer>
+  <license>Apache-2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <depend>bt_interfaces</depend>
+  <depend>other_interfaces</depend>
+  <depend>rclcpp</depend>
+  <depend>lifecycle_msgs</depend>
+  <depend>rclcpp_lifecycle</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+  <member_of_group>rosidl_interface_packages</member_of_group>
+  <exec_depend>rosidl_default_runtime</exec_depend>
+
+  <build_depend>rosidl_default_generators</build_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/ros2prova/stop_services_skill/src/StopServicesDataModel.cpp
+++ b/ros2prova/stop_services_skill/src/StopServicesDataModel.cpp
@@ -1,0 +1,116 @@
+/******************************************************************************
+ *                                                                            *
+ * Copyright (C) 2020 Fondazione Istituto Italiano di Tecnologia (IIT)        *
+ * All Rights Reserved.                                                       *
+ *                                                                            *
+ ******************************************************************************/
+#include "StopServicesDataModel.h"
+
+#include "lifecycle_msgs/msg/state.hpp"
+#include "lifecycle_msgs/msg/transition.hpp"
+
+#include <QDebug>
+#include <QTimer>
+#include <QScxmlStateMachine>
+
+
+
+void StopServicesDataModel::set_name(std::string name)
+{
+    m_name=name; 
+}
+
+bool StopServicesDataModel::setup(const QVariantMap &initialDataValues)
+{
+    Q_UNUSED(initialDataValues)
+
+    if(!rclcpp::ok())
+    {
+        rclcpp::init(/*argc*/ 0, /*argv*/ nullptr);
+    }
+
+    m_node = rclcpp::Node::make_shared(m_name);
+    m_client_get_state = m_node->create_client<lifecycle_msgs::srv::GetState>("/lc_talker/get_state");
+    m_client_change_state = m_node->create_client<lifecycle_msgs::srv::ChangeState>("/lc_talker/change_state");
+
+    RCLCPP_DEBUG(m_node->get_logger(), "StopServicesDataModel::start");
+    std::cout << "StopServicesDataModel::start";
+
+    return true;
+}
+
+bool StopServicesDataModel::is_client_available(const std::chrono::seconds& timeout) {
+
+    // Check if client is available, else return
+    bool is_client_available = m_client_get_state->wait_for_service(timeout);
+    if (!rclcpp::ok()) {
+        RCLCPP_ERROR(rclcpp::get_logger("rclcpp"), "Interrupted while waiting for the service. Exiting.");
+        return false;
+    }
+    if(!is_client_available){
+        RCLCPP_INFO(rclcpp::get_logger("rclcpp"), "service not available, aborting.");
+        return false;
+    }
+
+    return true;
+}
+
+std::optional<lifecycle_msgs::msg::State> StopServicesDataModel::get_state(const std::chrono::seconds& timeout) {
+
+    if(!is_client_available(timeout)) {
+        return std::nullopt;
+    }
+
+    // Get the state of the managed node
+    auto request = std::make_shared<lifecycle_msgs::srv::GetState::Request>();
+    auto result = m_client_get_state->async_send_request(request);
+    
+    if (rclcpp::spin_until_future_complete(m_node, result,timeout) == rclcpp::FutureReturnCode::SUCCESS)
+    {
+        RCLCPP_DEBUG(m_node->get_logger(), "StopServicesDataModel::get_state(). Success");
+        return result.get()->current_state;
+    } else {
+        RCLCPP_DEBUG(m_node->get_logger(), "StopServicesDataModel::get_state(). Failure");
+        return std::nullopt;
+    }
+
+}
+
+bool StopServicesDataModel::stop() {
+
+    if(!is_client_available()){
+        return false;
+    }
+
+    // Check if managed node is in state active and make it inactive
+    // Check https://github.com/ros2/rcl_interfaces/blob/humble/lifecycle_msgs/msg/State.msg for reference
+    std::optional<lifecycle_msgs::msg::State> current_state = this->get_state();
+    if(!current_state) {
+        return false;
+    }
+
+    if(current_state.value().id != lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE) {
+        RCLCPP_ERROR(m_node->get_logger(), "Cannot stop service since it is not active");
+        return false;
+    }
+    else {
+
+        // Change the state of the managed node to inactive
+        // Check https://github.com/ros2/rcl_interfaces/blob/humble/lifecycle_msgs/msg/Transition.msg for reference
+        auto request = std::make_shared<lifecycle_msgs::srv::ChangeState::Request>();
+        request->transition.id = lifecycle_msgs::msg::Transition::TRANSITION_DEACTIVATE;
+        
+        auto result = m_client_change_state->async_send_request(request);
+        
+        if (rclcpp::spin_until_future_complete(m_node,result,m_timeout) == rclcpp::FutureReturnCode::SUCCESS)
+        {
+            RCLCPP_DEBUG(m_node->get_logger(), "StopServicesDataModel::stop(). Success");
+            return true;
+        } else {
+            RCLCPP_DEBUG(m_node->get_logger(), "StopServicesDataModel::stop(). Failure");
+            return false;
+        }
+    }
+
+    return true;
+}

--- a/ros2prova/stop_services_skill/src/StopServicesSkill.cpp
+++ b/ros2prova/stop_services_skill/src/StopServicesSkill.cpp
@@ -1,0 +1,98 @@
+/******************************************************************************
+ *                                                                            *
+ * Copyright (C) 2020 Fondazione Istituto Italiano di Tecnologia (IIT)        *
+ * All Rights Reserved.                                                       *
+ *                                                                            *
+ ******************************************************************************/
+
+#include "StopServicesSkill.h"
+
+#include <QTimer>
+#include <QDebug>
+#include <QTime>
+#include <iostream>
+#include <QStateMachine>
+
+StopServicesSkill::StopServicesSkill(std::string name ) :
+        m_name(std::move(name))
+{
+    m_dataModel.set_name(name+"dataModel");
+    m_stateMachine.setDataModel(&m_dataModel);
+}
+
+
+void StopServicesSkill::spin(std::shared_ptr<rclcpp::Node> node)
+{
+    rclcpp::spin(node);  
+    rclcpp::shutdown();  
+}
+
+
+bool StopServicesSkill::start(int argc, char*argv[])
+{
+
+    if(!rclcpp::ok())
+    {
+        rclcpp::init(/*argc*/ argc, /*argv*/ argv);
+    }
+    m_node = rclcpp::Node::make_shared(m_name);
+
+    
+    RCLCPP_DEBUG(m_node->get_logger(), "StopServicesSkill::start");
+    std::cout << "StopServicesSkill::start";
+    m_requestAckService = m_node->create_service<bt_interfaces::srv::RequestAck>("/StopServicesSkill/RequestAck",  
+                                                                                std::bind(&StopServicesSkill::request_ack,
+                                                                                this,
+                                                                                std::placeholders::_1,
+                                                                                std::placeholders::_2));
+    m_sendStartService = m_node->create_service<bt_interfaces::srv::SendStart>("/StopServicesSkill/SendStart",  
+                                                                                std::bind(&StopServicesSkill::send_start,
+                                                                                this,
+                                                                                std::placeholders::_1,
+                                                                                std::placeholders::_2));
+    m_sendStopService = m_node->create_service<bt_interfaces::srv::SendStop>("/StopServicesSkill/SendStop",  
+                                                                                std::bind(&StopServicesSkill::send_stop,
+                                                                                this,
+                                                                                std::placeholders::_1,
+                                                                                std::placeholders::_2));
+
+    m_stateMachine.start();
+    m_threadSpin = std::make_shared<std::thread>(spin, m_node);
+    return true;
+}
+
+void StopServicesSkill::request_ack( [[maybe_unused]] const std::shared_ptr<bt_interfaces::srv::RequestAck::Request> request,
+                                       std::shared_ptr<bt_interfaces::srv::RequestAck::Response>      response)
+{
+    auto message = bt_interfaces::msg::RequestAck();
+        for (const auto& state : m_stateMachine.activeStateNames()) {
+            if (state == "stop") {
+                m_stateMachine.submitEvent("CMD_OK");
+                response->status.status = message.SKILL_RUNNING;
+            }
+            if (state == "idle") {
+                m_stateMachine.submitEvent("CMD_OK");
+                response->status.status = message.SKILL_IDLE;
+            }
+        }
+    response->is_ok = true;
+}
+
+void StopServicesSkill::send_start( [[maybe_unused]] const std::shared_ptr<bt_interfaces::srv::SendStart::Request> request,
+                                       [[maybe_unused]] std::shared_ptr<bt_interfaces::srv::SendStart::Response>      response)
+{
+    RCLCPP_DEBUG(m_node->get_logger(), "StopServicesSkill::send_start");    
+    std::cout << "StopServicesSkill::send_start";    
+    m_stateMachine.submitEvent("CMD_START");
+    response->is_ok = true;
+}
+
+void StopServicesSkill::send_stop( [[maybe_unused]] const std::shared_ptr<bt_interfaces::srv::SendStop::Request> request,
+                                       [[maybe_unused]] std::shared_ptr<bt_interfaces::srv::SendStop::Response>      response)
+{
+
+    RCLCPP_DEBUG(m_node->get_logger(), "StopServicesSkill::send_stop");    
+    std::cout <<  "StopServicesSkill::send_stop";    
+    m_stateMachine.submitEvent("CMD_STOP",  QStateMachine::HighPriority);
+    response->is_ok = true;
+}

--- a/ros2prova/stop_services_skill/src/StopServicesSkillSM.scxml
+++ b/ros2prova/stop_services_skill/src/StopServicesSkillSM.scxml
@@ -1,0 +1,22 @@
+<scxml 
+  initial="idle" 
+  version="1.0" 
+  name="StopServicesSkillSM"
+  datamodel="cplusplus:StopServicesDataModel:StopServicesDataModel.h"
+  xmlns="http://www.w3.org/2005/07/scxml">
+
+    <state id="stop">
+        <onentry>
+            <script>
+                stop();
+            </script>
+        </onentry>
+        <transition event="CMD_OK" target="idle"/>
+    </state>
+
+    <state id="idle">
+        <transition event="CMD_START" target="stop" />
+    </state>
+    
+</scxml>
+

--- a/ros2prova/stop_services_skill/src/main.cpp
+++ b/ros2prova/stop_services_skill/src/main.cpp
@@ -1,0 +1,25 @@
+#include <QCoreApplication>
+#include <QScxmlStateMachine>
+#include <QDebug>
+
+
+#include <iostream>
+#include "StopServicesSkill.h"
+
+#include <thread>
+#include <chrono>
+
+
+
+int main(int argc, char *argv[])
+{
+  QCoreApplication app(argc, argv);
+  StopServicesSkill stateMachine("StopServicesSkill");
+  stateMachine.start(argc, argv);
+
+  int ret=app.exec();
+  
+  return ret;
+  
+}
+


### PR DESCRIPTION
This PR is a draft including the check network skill and the start and stop service skill.
What has been tested:
- Check network skill correctly returns `not_connected` when the the connection of the laptop is manually turned off and returns `connected` when it can actually ping an address (try with `example.com`)
- Start and stop services can trigger a node transition respectively from inactive to active and viceversa.

There are still many things to be done:
- Names of the services to start and stop are hardcoded.
- Only one service at the time can be stopped for now
- CheckNetwork has to be tested under multiple network loss conditions. Since (for now) it is a wrapper + parser of the ping utility there might still be unexpected behaviours.

